### PR TITLE
Fix for error of grid degeneration after 2nd extrusion

### DIFF
--- a/skin_layer_generator.cpp
+++ b/skin_layer_generator.cpp
@@ -65,7 +65,7 @@ void SkinLayerGenerator::generate() {
 	SaveGridToFile(mesh->grid(), mesh->subset_handler(), "skin_layer_generator_step2.ugx");
 
 	FixFaceOrientation(mesh->grid(), mesh->grid().faces_begin(), mesh->grid().faces_end());
-	ExtrudeAlongNormal(mesh, m_injectionHeight, m_numStepsExtrudeInjection, true, true, true);
+	ExtrudeAlongNormal(mesh, m_injectionHeight, m_numStepsExtrudeInjection, true, true, false);
 	SaveGridToFile(mesh->grid(), mesh->subset_handler(), "skin_layer_generator_step3.ugx");
 
 	/// FixFaceOrientation(mesh->grid(), mesh->grid().faces_begin(), mesh->grid().faces_end());


### PR DESCRIPTION
Please merge, grid degeneration after 2nd extrusion was caused by using preCalculated normals in 2nd extrusion.